### PR TITLE
Fixed required attribute not being set correctly in the boltforms.bol…

### DIFF
--- a/Controller/FormEditorController.php
+++ b/Controller/FormEditorController.php
@@ -247,9 +247,9 @@ class FormEditorController implements ControllerProviderInterface
                 $fulldata[$formname]['fields'][$fieldkey]['type'] = $values['type'];
                 $fulldata[$formname]['fields'][$fieldkey]['options']['label'] = $values['label'];
                 if ($values['required'] == true) {
-                    $fulldata[$formname]['fields'][$fieldkey]['options']['required'] = true;
+                    $fulldata[$formname]['fields'][$fieldkey]['options']['attr']['required'] = true;
                 } else {
-                    $fulldata[$formname]['fields'][$fieldkey]['options']['required'] = false;
+                    $fulldata[$formname]['fields'][$fieldkey]['options']['attr']['required'] = false;
                 }
 
                 if ($values['type'] == 'choice') {
@@ -286,6 +286,15 @@ class FormEditorController implements ControllerProviderInterface
         foreach ($data['fields'] as $field => &$options) {
             $data['fields'][$field]['name'] = $field;
             $data['fields'][$field] = array_merge($data['fields'][$field], (array) $data['fields'][$field]['options']);
+
+            if (isset($data['fields'][$field]['attr'])) {
+                if (isset($data['fields'][$field]['attr']['required'])) //Add required attribute to form
+                    $data['fields'][$field]['required'] = $data['fields'][$field]['attr']['required'];
+
+            } else { //Default required to FALSE if not SET on form
+                $data['fields'][$field]['required'] = FALSE;
+            }
+
             if (isset($data['fields'][$field]['choices'])) {
                 $data['fields'][$field]['choices'] = implode(',', $data['fields'][$field]['choices']);
             }


### PR DESCRIPTION
The required attribute were not saving correctly in the boltforms.yml.dist. The attribute was just being added as a child to options instead of attr. 

The "required" fields were not populating correctly as well when editing the form fields.  On the edit page it displayed the required checkbox as not being required when required was set to TRUE in the boltforms.bolt.yml. 
