### PR TITLE
Made the label field not required in the FormElement type

### DIFF
--- a/Controller/FormEditorController.php
+++ b/Controller/FormEditorController.php
@@ -245,7 +245,10 @@ class FormEditorController implements ControllerProviderInterface
                 }
 
                 $fulldata[$formname]['fields'][$fieldkey]['type'] = $values['type'];
-                $fulldata[$formname]['fields'][$fieldkey]['options']['label'] = $values['label'];
+
+                if (! empty($valus['label']))
+                    $fulldata[$formname]['fields'][$fieldkey]['options']['label'] = $values['label'];
+
                 if ($values['required'] == true) {
                     $fulldata[$formname]['fields'][$fieldkey]['options']['required'] = true;
                 } else {

--- a/Form/FormelementType.php
+++ b/Form/FormelementType.php
@@ -21,6 +21,7 @@ class FormelementType extends AbstractType
             ->add('label',   'text', [
                 'label' => 'Label for this form field',
                 'attr' => ['help' => 'This is the user-visible label'],
+                'required' => FALSE
             ])
             ->add('type',   'choice', [
                 'label' => 'Type of form element',


### PR DESCRIPTION
By default the label is filled with an empty value if you fill it with just a space or nothing. The label isn't needed for submit buttons. Maybe the logic should be changed to only make labels required when there is something other than a button....
