### PR TITLE
Small Improvement - Make the file location configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-
+composer.lock
+vendor

--- a/config.yml.dist
+++ b/config.yml.dist
@@ -13,3 +13,5 @@ defaults:
     database:
 #       contenttype: feedback
     fields: {}
+
+file: config/extensions/boltforms.bolt.yml

--- a/src/Controller/FormEditorController.php
+++ b/src/Controller/FormEditorController.php
@@ -330,7 +330,7 @@ class FormEditorController implements ControllerProviderInterface
      */
     protected function read()
     {
-        $file = $this->app['resources']->getPath('config/extensions/boltforms.bolt.yml');
+        $file = $this->app['resources']->getPath($this->config['file']);
         $yaml = file_get_contents($file);
         $parser = new Parser();
         $data = $parser->parse($yaml);


### PR DESCRIPTION
Just in case the bolt forms config file is in a different location or you want to switch to edit forms in a `.local` version of the file then this options will allow that.